### PR TITLE
JavaCrossCompilePlugin: avoid configuration if Java Toolchains are used

### DIFF
--- a/src/integTest/groovy/nebula/plugin/compile/JavaCrossCompilePluginIntegrationSpec.groovy
+++ b/src/integTest/groovy/nebula/plugin/compile/JavaCrossCompilePluginIntegrationSpec.groovy
@@ -82,7 +82,9 @@ class JavaCrossCompilePluginIntegrationSpec extends IntegrationSpec {
 
         where:
         gradle    | _
-        '4.2.1'   | _
+        '6.7'   | _
+        '6.8'   | _
+        '6.9'   | _
         'current' | _
     }
 
@@ -111,5 +113,28 @@ class JavaCrossCompilePluginIntegrationSpec extends IntegrationSpec {
 
         expect:
         def result = runTasksSuccessfully('help')
+    }
+
+    @Unroll
+    def 'Do not apply opinions if using Java Toolchains'() {
+        buildFile << """\
+            apply plugin: 'nebula.java-cross-compile'
+            apply plugin: 'java'
+            
+
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(16)
+                }
+            }
+        """
+
+        writeHelloWorld('helloworld')
+
+        when:
+        def result = runTasks('compileJava', '-d')
+
+        then:
+        result.standardOutput.contains("Toolchain is configured for this project, skipping java-cross-compile plugin configuration")
     }
 }

--- a/src/main/kotlin/nebula/plugin/compile/JavaCrossCompilePlugin.kt
+++ b/src/main/kotlin/nebula/plugin/compile/JavaCrossCompilePlugin.kt
@@ -12,8 +12,10 @@ import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
 import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.plugins.JavaPluginConvention
+import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.compile.JavaCompile
+import org.gradle.jvm.toolchain.internal.DefaultToolchainSpec
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jetbrains.kotlin.utils.addToStdlib.firstNotNullResult
 import org.slf4j.Logger
@@ -43,6 +45,13 @@ class JavaCrossCompilePlugin @Inject constructor(private val providerFactory: Pr
             return
         }
         val convention = project.convention.plugins["java"] as JavaPluginConvention? ?: return
+
+        // Do not configure project if toolchains are used
+        val toolchain = project.extensions.getByType(JavaPluginExtension::class.java).toolchain
+        if((toolchain as DefaultToolchainSpec).isConfigured) {
+            project.logger.debug("Toolchain is configured for this project, skipping java-cross-compile plugin configuration")
+            return
+        }
         val targetCompatibility = convention.targetCompatibility
         if (targetCompatibility < JavaVersion.current()) {
             with(project.tasks) {


### PR DESCRIPTION
This is a breaking change

```
 val toolchain = project.extensions.getByType(JavaPluginExtension::class.java).toolchain
``` 

`toolchain` is `Incubating` and only available in modern versions of Gradle (6.7+)

I think this is fair in order to determine if we are using toolchains and avoid configuring the compilation and such